### PR TITLE
Fixed example of "@Ignore with reason"

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -24,7 +24,7 @@ For documentation purposes, a reason can be provided:
 
 [source,groovy]
 ----
-@Ignore(reason = "TODO")
+@Ignore("TODO")
 def "my feature"() { ... }
 ----
 


### PR DESCRIPTION
The example used a non-existing `reason` key instead of the implicit `value` to provide the reason (as mentioned in issue #56)